### PR TITLE
パフォーマンス改善

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -7,11 +7,13 @@ version = "0.1.0"
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 Printf = "de0858da-6303-5e67-8744-51eddeeeb8d7"
+StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
 
 [compat]
 Dates = "1.11.0"
 LinearAlgebra = "1.11.0"
 Printf = "1.11.0"
+StaticArrays = "1.9.8"
 
 [extras]
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"

--- a/src/Fluid2d/Conserved.jl
+++ b/src/Fluid2d/Conserved.jl
@@ -1,17 +1,18 @@
 module Conserved
+using StaticArrays: @SVector
 # construction of each terms in conservative equation
-using ..Eos: calc_p 
+using ..Eos: calc_p
 
 # conservative var from basic var
 function calc_conserv(rho, u, v, e, s)
-  return [rho*s, rho*u*s, rho*v*s, e*s]
+  return @SVector [rho*s, rho*u*s, rho*v*s, e*s]
 end
 
 # convective flux from basic var
 function calc_flux_conv(rho,u,v,e,ixs,iys,eos)
   bigu = ixs*u + iys*v
   p = calc_p(rho,u,v,e,eos)
-  return [rho*bigu, rho*u*bigu + ixs*p, rho*v*bigu + iys*p, (e+p)*bigu]
+  return @SVector [rho*bigu, rho*u*bigu + ixs*p, rho*v*bigu + iys*p, (e+p)*bigu]
 end
 
 # basic var from conservative var

--- a/src/Fluid2d/Eos.jl
+++ b/src/Fluid2d/Eos.jl
@@ -1,6 +1,8 @@
 module Eos
 
 using LinearAlgebra
+using StaticArrays: @SMatrix
+
 import ..IdealEoS
 # Equation of state
 
@@ -39,14 +41,21 @@ function calc_eigen(rho,u,v,e,ix,iy,eos::IdealEoS)
   b1 = 0.5*(u*u+v*v)*(eos.gam-1.0)/cs/cs
   b2 = (eos.gam-1.0)/cs/cs
   # diagonal matrix of eigen values
-  dia_lam = Diagonal([bigu-cs*sqr, bigu, bigu+cs*sqr, bigu])
+  # dia_lam = Diagonal([bigu-cs*sqr, bigu, bigu+cs*sqr, bigu])
+
+  dia_lam = @SMatrix [
+    bigu-cs*sqr 0.0 0.0 0.0;
+    0.0 bigu 0.0 0.0;
+    0.0 0.0 bigu+cs*sqr 0.0;
+    0.0 0.0 0.0 bigu
+  ]
   # right eigen matrix
-  mat_r = [1.0          1.0              1.0             0.0;
+  mat_r = @SMatrix [1.0          1.0              1.0             0.0;
           (u - ixb*cs)  u                (u + ixb*cs)    (-iyb);
           (v - iyb*cs)  v                (v + iyb*cs)     ixb;
           (h - cs*bigub)  0.5*(u*u+v*v)  (h + cs*bigub)  (-(iyb*u - ixb*v))]
   # inverse of righr eigen matrix
-  mat_rinv = [0.5*(b1 + bigub/cs)  (-0.5*(ixb/cs + b2*u))  (-0.5*(iyb/cs + b2*v))  0.5*b2;
+  mat_rinv = @SMatrix [0.5*(b1 + bigub/cs)  (-0.5*(ixb/cs + b2*u))  (-0.5*(iyb/cs + b2*v))  0.5*b2;
               (1.0 - b1)           b2*u                    b2*v                    (-b2);
               0.5*(b1 - bigub/cs)  0.5*(ixb/cs - b2*u)     0.5*(iyb/cs - b2*v)     0.5*b2;
               (iyb*u - ixb*v)      (-iyb)                  ixb                     0.0]

--- a/src/Fluid2d/Marching.jl
+++ b/src/Fluid2d/Marching.jl
@@ -54,7 +54,7 @@ function march_ssprk3(dt, bc_type, reconstruction, flux_scheme, basic::BasicVarH
       # inverse of Jacobian: averaging adjacent 4 values
       s_a = 0.25 * (coord.s[NB+i-1,NB+j-1] + coord.s[NB+i,NB+j-1] + coord.s[NB+i-1,NB+j] + coord.s[NB+i,NB+j])
       # update basic var
-      basic.rho[NB+i,NB+j], basic.u[NB+i,NB+j], basic.v[NB+i,NB+j], basic.e[NB+i,NB+j] = calc_basic(arr_q1[:,i,j],s_a)
+      basic.rho[NB+i,NB+j], basic.u[NB+i,NB+j], basic.v[NB+i,NB+j], basic.e[NB+i,NB+j] = calc_basic(@view(arr_q1[:,i,j]),s_a)
     end
   end
   reflect_bc(bc_type, basic, eos)
@@ -80,7 +80,7 @@ function march_ssprk3(dt, bc_type, reconstruction, flux_scheme, basic::BasicVarH
       # inverse of Jacobian: averaging adjacent 4 values
       s_a = 0.25 * (coord.s[NB+i-1,NB+j-1] + coord.s[NB+i,NB+j-1] + coord.s[NB+i-1,NB+j] + coord.s[NB+i,NB+j])
       # update basic var
-      basic.rho[NB+i,NB+j], basic.u[NB+i,NB+j], basic.v[NB+i,NB+j], basic.e[NB+i,NB+j] = calc_basic(arr_q0[:,i,j],s_a)
+      basic.rho[NB+i,NB+j], basic.u[NB+i,NB+j], basic.v[NB+i,NB+j], basic.e[NB+i,NB+j] = calc_basic(@view(arr_q0[:,i,j]),s_a)
     end
   end
   reflect_bc(bc_type, basic, eos)

--- a/src/Fluid2d/Marching.jl
+++ b/src/Fluid2d/Marching.jl
@@ -42,7 +42,7 @@ function march_ssprk3(dt, bc_type, reconstruction, flux_scheme, basic::BasicVarH
     for i = 1:NI-2*NB
       # inverse of Jacobian: averaging adjacent 4 values
       s_a = 0.25 * (coord.s[NB+i-1,NB+j-1] + coord.s[NB+i,NB+j-1] + coord.s[NB+i-1,NB+j] + coord.s[NB+i,NB+j])
-      arr_q0[:,i,j] = calc_conserv(basic.rho[NB+i,NB+j],basic.u[NB+i,NB+j],basic.v[NB+i,NB+j],basic.e[NB+i,NB+j],s_a)
+      arr_q0[:,i,j] .= calc_conserv(basic.rho[NB+i,NB+j],basic.u[NB+i,NB+j],basic.v[NB+i,NB+j],basic.e[NB+i,NB+j],s_a)
     end
   end
 
@@ -67,7 +67,7 @@ function march_ssprk3(dt, bc_type, reconstruction, flux_scheme, basic::BasicVarH
       # inverse of Jacobian: averaging adjacent 4 values
       s_a = 0.25 * (coord.s[NB+i-1,NB+j-1] + coord.s[NB+i,NB+j-1] + coord.s[NB+i-1,NB+j] + coord.s[NB+i,NB+j])
       # update basic var
-      basic.rho[NB+i,NB+j], basic.u[NB+i,NB+j], basic.v[NB+i,NB+j], basic.e[NB+i,NB+j] = calc_basic(arr_q2[:,i,j],s_a)
+      basic.rho[NB+i,NB+j], basic.u[NB+i,NB+j], basic.v[NB+i,NB+j], basic.e[NB+i,NB+j] = calc_basic(@view(arr_q2[:,i,j]),s_a)
     end
   end
   reflect_bc(bc_type, basic, eos)


### PR DESCRIPTION
ソースコードのパフォーマンスを計測したところ `calc_eigen` がかなり時間がかかっていました．`mat_r`, `mat_rinv` など行列オブジェクトを生成する箇所などです．今回の場合は 4x4 など小さいサイズかつ固定長の行列を扱っているので StaticArrays.jl を使うと良いと感じました．C++ でいえば `Eigen::Matrix4d` に相当するものです．

- https://github.com/JuliaArrays/StaticArrays.jl
- https://zenn.dev/hyrodium/articles/5aa5366062f702

`src/Fluid2d/Eq.jl` などにdは `@view` マクロを使っています．`basic.rho[NB+i-3:NB+i+2,NB+j]` のようにすると参照ではなくコピーが発生しメモリアロケーションが発生します．それによるガベージコレクションのコストが無視できなかったので `@view` などのマクロを使って対応しています．

また，小さな改善ですが，Qiita の記事にもあるように `.=` を使った代入を必要に応じて用いています．

てもの環境では 22 分ほどまで短縮できました．