### PR TITLE
パフォーマンス改善 part2

### DIFF
--- a/Main.jl
+++ b/Main.jl
@@ -2,11 +2,12 @@ using Fluid2d
 using Dates
 
 function iteration(tstep, dt_out, t, iter, fluid::IdealGas)
+  qbuff = Fluid2d.ArrayBuffer(fluid.basic)
   while t < tstep * dt_out
     # CFL condition
     dt = calc_cfl(0.7, fluid.basic, fluid.coord, fluid.eos)
     # marching
-    march_ssprk3(dt, "periodical_in_i", "MP5_basic", "Roe_FDS", fluid.basic, fluid.coord, fluid.eos, fluid.eq)
+    march_ssprk3(qbuff, dt, "periodical_in_i", "MP5_basic", "Roe_FDS", fluid.basic, fluid.coord, fluid.eos, fluid.eq)
     t = t + dt
     iter = iter + 1
   end

--- a/src/Fluid2d.jl
+++ b/src/Fluid2d.jl
@@ -38,6 +38,26 @@ mutable struct BasicVarHD
   BasicVarHD(NI, NJ, NB) = new(NI, NJ, NB, zeros(NI,NJ), zeros(NI,NJ), zeros(NI,NJ), zeros(NI,NJ))
 end
 
+
+struct ArrayBuffer
+  arr_q0::Array{Float64, 3}
+  arr_q1::Array{Float64, 3}
+  arr_q2::Array{Float64, 3}
+  arr_fi::Array{Float64, 3}
+  arr_fj::Array{Float64, 3}
+  arr_rhs::Array{Float64, 3}
+  function ArrayBuffer(basic::BasicVarHD)
+    (; NI, NB, NJ, NB) = basic
+    arr_q0 = zeros(NB,NI-2*NB,NJ-2*NB)
+    arr_q1 = zeros(NB,NI-2*NB,NJ-2*NB)
+    arr_q2 = zeros(NB,NI-2*NB,NJ-2*NB)
+    arr_fi = zeros(NB,NI-2*NB+1,NJ-2*NB)
+    arr_fj = zeros(NB,NI-2*NB,NJ-2*NB+1)
+    arr_rhs = zeros(NB,NI-2*NB,NJ-2*NB)
+    new(arr_q0, arr_q1, arr_q2, arr_fi, arr_fj, arr_rhs)
+  end
+end
+
 struct EulerEq
   # no member variables
 end

--- a/src/Fluid2d/Eos.jl
+++ b/src/Fluid2d/Eos.jl
@@ -1,7 +1,7 @@
 module Eos
 
 using LinearAlgebra
-using StaticArrays: @SMatrix
+using StaticArrays: @SMatrix, @SVector
 
 import ..IdealEoS
 # Equation of state
@@ -43,12 +43,8 @@ function calc_eigen(rho,u,v,e,ix,iy,eos::IdealEoS)
   # diagonal matrix of eigen values
   # dia_lam = Diagonal([bigu-cs*sqr, bigu, bigu+cs*sqr, bigu])
 
-  dia_lam = @SMatrix [
-    bigu-cs*sqr 0.0 0.0 0.0;
-    0.0 bigu 0.0 0.0;
-    0.0 0.0 bigu+cs*sqr 0.0;
-    0.0 0.0 0.0 bigu
-  ]
+  dia_lam = Diagonal(@SVector [bigu-cs*sqr, bigu, bigu+cs*sqr, bigu])
+
   # right eigen matrix
   mat_r = @SMatrix [1.0          1.0              1.0             0.0;
           (u - ixb*cs)  u                (u + ixb*cs)    (-iyb);

--- a/src/Fluid2d/Eos.jl
+++ b/src/Fluid2d/Eos.jl
@@ -38,8 +38,9 @@ end
   iyb = iy/sqr
   bigu = ix*u + iy*v
   bigub = bigu/sqr
-  b1 = 0.5*(u*u+v*v)*(eos.gam-1.0)/cs/cs
-  b2 = (eos.gam-1.0)/cs/cs
+  cscs = cs^2
+  b1 = 0.5*(u*u+v*v)*(eos.gam-1.0)/cscs
+  b2 = (eos.gam-1.0)/cscs
   # diagonal matrix of eigen values
   # dia_lam = Diagonal([bigu-cs*sqr, bigu, bigu+cs*sqr, bigu])
 
@@ -51,9 +52,10 @@ end
           (v - iyb*cs)  v                (v + iyb*cs)     ixb;
           (h - cs*bigub)  0.5*(u*u+v*v)  (h + cs*bigub)  (-(iyb*u - ixb*v))]
   # inverse of righr eigen matrix
-  mat_rinv = @SMatrix [0.5*(b1 + bigub/cs)  (-0.5*(ixb/cs + b2*u))  (-0.5*(iyb/cs + b2*v))  0.5*b2;
+  inv_cs = inv(cs)
+  mat_rinv = @SMatrix [0.5*(b1 + bigub * inv_cs)  (-0.5*(ixb * inv_cs + b2*u))  (-0.5*(iyb * inv_cs + b2*v))  0.5*b2;
               (1.0 - b1)           b2*u                    b2*v                    (-b2);
-              0.5*(b1 - bigub/cs)  0.5*(ixb/cs - b2*u)     0.5*(iyb/cs - b2*v)     0.5*b2;
+              0.5*(b1 - bigub * inv_cs)  0.5*(ixb * inv_cs - b2*u)     0.5*(iyb * inv_cs - b2*v)     0.5*b2;
               (iyb*u - ixb*v)      (-iyb)                  ixb                     0.0]
   return dia_lam, mat_r, mat_rinv
 end

--- a/src/Fluid2d/Eos.jl
+++ b/src/Fluid2d/Eos.jl
@@ -8,16 +8,16 @@ import ..IdealEoS
 
 # EoS for ideal gas
 
-function calc_p(rho,u,v,e,eos::IdealEoS)
+@inline function calc_p(rho,u,v,e,eos::IdealEoS)
   return (eos.gam-1.0)*(e - 0.5*rho*(u*u+v*v))
 end
 function calc_temp(rho,u,v,e,eos::IdealEoS)
   return e/rho - 0.5*(u*u+v*v)
 end
-function calc_cs(rho,u,v,e,eos::IdealEoS)
+@inline function calc_cs(rho,u,v,e,eos::IdealEoS)
   return sqrt(eos.gam*(eos.gam-1.0)*(e/rho - 0.5*(u*u+v*v)))
 end
-function calc_e(rho,u,v,h,eos::IdealEoS)
+@inline function calc_e(rho,u,v,h,eos::IdealEoS)
   return rho*(h + (eos.gam-1.0)*0.5*(u*u+v*v))/eos.gam
 end
 function calc_rho_e(p,temp,u,v,eos::IdealEoS)
@@ -29,7 +29,7 @@ function calc_e_wp(rho,u,v,p,eos::IdealEoS)
   return p/(eos.gam-1.0) + 0.5*rho*(u*u+v*v)
 end
 # calc eigen values/vectors of flux Jacobian
-function calc_eigen(rho,u,v,e,ix,iy,eos::IdealEoS)
+@inline function calc_eigen(rho,u,v,e,ix,iy,eos::IdealEoS)
   cs = calc_cs(rho,u,v,e,eos)
   p = calc_p(rho,u,v,e,eos)
   h = (e+p)/rho

--- a/src/Fluid2d/Eq.jl
+++ b/src/Fluid2d/Eq.jl
@@ -86,9 +86,10 @@ function calc_rhs(arrbuff::ArrayBuffer, reconstruction, flux_scheme, basic::Basi
   end # for j
 
   # evaluating RHS
+  fill!(arrbuff.arr_rhs, 0.0)
   arr_rhs = arrbuff.arr_rhs
-  arr_rhs .= @view arr_fi[:,1:NI-2*NB,:]
-  arr_rhs .-= @view arr_fi[:,1:NI-2*NB,:]
+  arr_rhs .+= @view arr_fi[:,1:NI-2*NB,:]
+  arr_rhs .-= @view arr_fi[:,2:NI-2*NB+1,:]
   arr_rhs .+= @view arr_fj[:,:,1:NJ-2*NB]
   arr_rhs .-= @view arr_fj[:,:,2:NJ-2*NB+1]
   return arr_rhs

--- a/src/Fluid2d/Eq.jl
+++ b/src/Fluid2d/Eq.jl
@@ -1,18 +1,19 @@
 module Eq
 
+import ..ArrayBuffer
 import ..BasicVarHD
 import ..GenStructCoord
 import ..EulerEq
 using ..FluxScheme: reconst_by_basic_muscl, reconst_by_basic_mp5, calc_num_flux
 
 # calc RHS with selected reconstruction/flux scheme
-function calc_rhs(reconstruction, flux_scheme, basic::BasicVarHD, coord::GenStructCoord, eos, eq::EulerEq)
+function calc_rhs(arrbuff::ArrayBuffer, reconstruction, flux_scheme, basic::BasicVarHD, coord::GenStructCoord, eos, eq::EulerEq)
 
   NI = basic.NI
   NJ = basic.NJ
   NB = basic.NB
-  arr_fi = zeros(4,NI-2*NB+1,NJ-2*NB)
-  arr_fj = zeros(4,NI-2*NB,NJ-2*NB+1)
+  arr_fi = arrbuff.arr_fi
+  arr_fj = arrbuff.arr_fj
 
   # i-direction
   # evaluating numerical flux at (i+0.5,j)
@@ -85,7 +86,12 @@ function calc_rhs(reconstruction, flux_scheme, basic::BasicVarHD, coord::GenStru
   end # for j
 
   # evaluating RHS
-  return @views @. arr_fi[:,1:NI-2*NB,:] - arr_fi[:,2:NI-2*NB+1,:] + arr_fj[:,:,1:NJ-2*NB] - arr_fj[:,:,2:NJ-2*NB+1]
+  arr_rhs = arrbuff.arr_rhs
+  arr_rhs .= @view arr_fi[:,1:NI-2*NB,:]
+  arr_rhs .-= @view arr_fi[:,1:NI-2*NB,:]
+  arr_rhs .+= @view arr_fj[:,:,1:NJ-2*NB]
+  arr_rhs .-= @view arr_fj[:,:,2:NJ-2*NB+1]
+  return arr_rhs
 end # function calc_rhs
 
 # export calc_rhs

--- a/src/Fluid2d/Eq.jl
+++ b/src/Fluid2d/Eq.jl
@@ -17,7 +17,7 @@ function calc_rhs(arrbuff::ArrayBuffer, reconstruction, flux_scheme, basic::Basi
 
   # i-direction
   # evaluating numerical flux at (i+0.5,j)
-  for j = 1:NJ-2*NB
+  @inbounds for j = 1:NJ-2*NB
     for i = 1:NI-2*NB+1
 
       # inverse of Jacobian is evaluated
@@ -53,7 +53,7 @@ function calc_rhs(arrbuff::ArrayBuffer, reconstruction, flux_scheme, basic::Basi
 
   # j-direction
   # evaluating numerical flux at (i,j+0.5)
-  for j = 1:NJ-2*NB+1
+  @inbounds for j = 1:NJ-2*NB+1
     for i = 1:NI-2*NB
 
       # inverse of Jacobian is evaluated

--- a/src/Fluid2d/FluxScheme.jl
+++ b/src/Fluid2d/FluxScheme.jl
@@ -18,10 +18,12 @@ end
 
 # reconstruct by basic variables with MP5
 function reconst_by_basic_mp5(rho,u,v,e)
-  rho_l, rho_r = mp5(rho[1],rho[2],rho[3],rho[4],rho[5],rho[6])
-  u_l, u_r = mp5(u[1],u[2],u[3],u[4],u[5],u[6])
-  v_l, v_r = mp5(v[1],v[2],v[3],v[4],v[5],v[6])
-  e_l, e_r = mp5(e[1],e[2],e[3],e[4],e[5],e[6])
+  @inbounds begin
+    rho_l, rho_r = mp5(rho[1],rho[2],rho[3],rho[4],rho[5],rho[6])
+    u_l, u_r = mp5(u[1],u[2],u[3],u[4],u[5],u[6])
+    v_l, v_r = mp5(v[1],v[2],v[3],v[4],v[5],v[6])
+    e_l, e_r = mp5(e[1],e[2],e[3],e[4],e[5],e[6])
+  end
   return rho_l, u_l, v_l, e_l, rho_r, u_r, v_r, e_r
 end
 

--- a/src/Fluid2d/FluxScheme.jl
+++ b/src/Fluid2d/FluxScheme.jl
@@ -46,9 +46,10 @@ function roe_average(rho_l,u_l,v_l,e_l,rho_r,u_r,v_r,e_r,eos)
   sqr_r = sqrt(rho_r)
 
   rho_a = sqr_l * sqr_r
-  u_a = (sqr_l*u_l + sqr_r*u_r)/(sqr_l + sqr_r)
-  v_a = (sqr_l*v_l + sqr_r*v_r)/(sqr_l + sqr_r)
-  h_a = (sqr_l*h_l + sqr_r*h_r)/(sqr_l + sqr_r)
+  inv_sqr_l_plus_sqr_r = inv(sqr_l + sqr_r)
+  u_a = (sqr_l*u_l + sqr_r*u_r) * inv_sqr_l_plus_sqr_r
+  v_a = (sqr_l*v_l + sqr_r*v_r) * inv_sqr_l_plus_sqr_r
+  h_a = (sqr_l*h_l + sqr_r*h_r) * inv_sqr_l_plus_sqr_r
   e_a = calc_e(rho_a,u_a,v_a,h_a,eos)
   return rho_a,u_a,v_a,e_a
 end
@@ -65,7 +66,6 @@ function roe_fds(rho_l, u_l, v_l, e_l, rho_r, u_r, v_r, e_r, ixs, iys, s, eos)
   vec_f_l = calc_flux_conv(rho_l,u_l,v_l,e_l,ixs,iys,eos)
   vec_f_r = calc_flux_conv(rho_r,u_r,v_r,e_r,ixs,iys,eos)
   dia_lam, mat_r, mat_rinv = calc_eigen(rho_a,u_a,v_a,e_a,ix,iy,eos)
-
   vec_fc = 0.5 .* (vec_f_r .+ vec_f_l  .- mat_r * abs.(dia_lam) * mat_rinv * (vec_q_r .- vec_q_l))
 
   return vec_fc

--- a/src/Fluid2d/Fnd.jl
+++ b/src/Fluid2d/Fnd.jl
@@ -10,7 +10,7 @@ function minmod(x1,x2,x3,x4)
 end
 
 # MUSCL-minmod
-function muscl_minmod(qm,q,qp,q2p)
+@inline function muscl_minmod(qm,q,qp,q2p)
   k = 1.0/3.0
   b = (3.0-k)/(1.0-k)
   # calc of L
@@ -28,11 +28,11 @@ function muscl_minmod(qm,q,qp,q2p)
   return q_l, q_r
 end
 
-function median(x,y,z)
+@inline function median(x,y,z)
   return x + minmod(y-x,z-x)
 end
 
-function mp5_sub(q2m,qm,q,qp,q2p)
+@inline function mp5_sub(q2m,qm,q,qp,q2p)
   alp = 2.0
   q_l = (2.0 * q2m - 13.0 * qm + 47.0 * q + 27.0 * qp - 3.0 * q2p) / 60.0
   q_mp = q + minmod(qp - q, alp * (q - qm))
@@ -53,7 +53,7 @@ function mp5_sub(q2m,qm,q,qp,q2p)
 end
 
 # MP5
-function mp5(q2m,qm,q,qp,q2p,q3p)
+@inline function mp5(q2m,qm,q,qp,q2p,q3p)
   q_l = mp5_sub(q2m,qm,q,qp,q2p)
   q_r = mp5_sub(q3p,q2p,qp,q,qm)
   return q_l, q_r

--- a/src/Fluid2d/Fnd.jl
+++ b/src/Fluid2d/Fnd.jl
@@ -1,12 +1,39 @@
 module Fnd
 # reconstruction schemes are defined
 
+#=
+@inline function minmod(x, y)
+  sx = sign(x)
+  return sx * max(min(abs(x), sx*y), zero(x))
+end
+=#
+
 function minmod(x, y)
-  return sign(x) * max(min(abs(x), sign(x)*y), 0.0)
+  if x > 0
+	  sx = one(x)
+      sx * max(min(x, sx*y), zero(x))
+  elseif x < 0
+	  sx = -one(x)
+	  sx * max(min(-x, sx*y), zero(x))
+  else
+	  zero(x)
+  end
 end
 
+#=
+@inline function minmod(x1,x2,x3,x4)
+  s1 = sign(x1)
+  return 0.5*(s1+sign(x2))*abs(0.5*(s1+sign(x3))*0.5*(s1+sign(x4)))*min(abs(x1),abs(x2),abs(x3),abs(x4))
+end
+=#
+
 function minmod(x1,x2,x3,x4)
-  return 0.5*(sign(x1)+sign(x2))*abs(0.5*(sign(x1)+sign(x3))*0.5*(sign(x1)+sign(x4)))*min(abs(x1),abs(x2),abs(x3),abs(x4))
+  s1 = sign(x1)
+  return 0.5*0.5*0.5*
+    (s1+sign(x2)) *
+    abs((s1+sign(x3))*
+      (s1+sign(x4))) *
+     min(min(abs(x1),abs(x2)),min(abs(x3),abs(x4)))
 end
 
 # MUSCL-minmod
@@ -45,8 +72,8 @@ end
     q_ul = q + alp * (q - qm)
     q_md = 0.5 * (q + qp) - 0.5 * d_mp
     q_lc = q + 0.5 * (q - qm) + 4.0 / 3.0 * d_mm
-    qmin = max(min(q,qp,q_md),min(q,q_ul,q_lc))
-    qmax = min(max(q,qp,q_md),max(q,q_ul,q_lc))
+    qmin = max(min(min(q,qp),min(q_md)),min(min(q,q_ul),min(q_lc)))
+    qmax = min(max(max(q,qp),max(q_md)),max(max(q,q_ul),max(q_lc)))
     q_l = median(q_l,qmin,qmax)
   end
   return q_l

--- a/src/Fluid2d/Marching.jl
+++ b/src/Fluid2d/Marching.jl
@@ -39,7 +39,7 @@ function march_ssprk3(arrbuff::ArrayBuffer, dt, bc_type, reconstruction, flux_sc
 
   # construct conservative var
   arr_q0 = arrbuff.arr_q0
-  for j = 1:NJ-2*NB
+  @inbounds for j = 1:NJ-2*NB
     for i = 1:NI-2*NB
       # inverse of Jacobian: averaging adjacent 4 values
       s_a = 0.25 * (coord.s[NB+i-1,NB+j-1] + coord.s[NB+i,NB+j-1] + coord.s[NB+i-1,NB+j] + coord.s[NB+i,NB+j])
@@ -51,7 +51,7 @@ function march_ssprk3(arrbuff::ArrayBuffer, dt, bc_type, reconstruction, flux_sc
   arr_q1 = arrbuff.arr_q1
   arr_q1 .= calc_rhs(arrbuff, reconstruction, flux_scheme, basic, coord, eos, eq)
   arr_q1 .= arr_q0 .+ dt .* arr_q1
-  for j = 1:NJ-2*NB
+  @inbounds for j = 1:NJ-2*NB
     for i = 1:NI-2*NB
       # inverse of Jacobian: averaging adjacent 4 values
       s_a = 0.25 * (coord.s[NB+i-1,NB+j-1] + coord.s[NB+i,NB+j-1] + coord.s[NB+i-1,NB+j] + coord.s[NB+i,NB+j])
@@ -65,7 +65,7 @@ function march_ssprk3(arrbuff::ArrayBuffer, dt, bc_type, reconstruction, flux_sc
   arr_q2 = arrbuff.arr_q2
   arr_q2 .= calc_rhs(arrbuff, reconstruction, flux_scheme, basic, coord, eos, eq)
   arr_q2 .= 0.75 .* arr_q0 .+ 0.25 .* (arr_q1 .+ dt .* arr_q2)
-  for j = 1:NJ-2*NB
+  @inbounds  for j = 1:NJ-2*NB
     for i = 1:NI-2*NB
       # inverse of Jacobian: averaging adjacent 4 values
       s_a = 0.25 * (coord.s[NB+i-1,NB+j-1] + coord.s[NB+i,NB+j-1] + coord.s[NB+i-1,NB+j] + coord.s[NB+i,NB+j])
@@ -78,7 +78,7 @@ function march_ssprk3(arrbuff::ArrayBuffer, dt, bc_type, reconstruction, flux_sc
   # 3rd stage
   arr_q1 .= calc_rhs(arrbuff, reconstruction, flux_scheme, basic, coord, eos, eq)
   arr_q0 .= arr_q0 ./ 3.0 .+ 2.0 ./ 3.0 .* (arr_q2 .+ dt .* arr_q1)
-  for j = 1:NJ-2*NB
+  @inbounds for j = 1:NJ-2*NB
     for i = 1:NI-2*NB
       # inverse of Jacobian: averaging adjacent 4 values
       s_a = 0.25 * (coord.s[NB+i-1,NB+j-1] + coord.s[NB+i,NB+j-1] + coord.s[NB+i-1,NB+j] + coord.s[NB+i,NB+j])

--- a/src/Fluid2d/Marching.jl
+++ b/src/Fluid2d/Marching.jl
@@ -38,8 +38,8 @@ function march_ssprk3(arrbuff::ArrayBuffer, dt, bc_type, reconstruction, flux_sc
   NB = basic.NB
 
   # construct conservative var
-  for j = 1:NJ-2*NB
   arr_q0 = arrbuff.arr_q0
+  for j = 1:NJ-2*NB
     for i = 1:NI-2*NB
       # inverse of Jacobian: averaging adjacent 4 values
       s_a = 0.25 * (coord.s[NB+i-1,NB+j-1] + coord.s[NB+i,NB+j-1] + coord.s[NB+i-1,NB+j] + coord.s[NB+i,NB+j])

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,6 +1,7 @@
 using Test
 
 using Fluid2d
+using Fluid2d.Fnd: minmod
 using Dates
 
 @testset "Fluid2d" begin
@@ -29,3 +30,37 @@ using Dates
     @test size(fluid.coord.x) == (NI, NJ)
 end
 
+function minmod_orig(x, y)
+  return sign(x) * max(min(abs(x), sign(x)*y), zero(x))
+end
+
+function minmod_orig(x1,x2,x3,x4)
+  s1 = sign(x1)
+  return 0.5*(s1+sign(x2))*abs(0.5*(s1+sign(x3))*0.5*(s1+sign(x4)))*min(abs(x1),abs(x2),abs(x3),abs(x4))
+end
+
+@testset "minmod(x,y)" begin
+    y = rand()
+    x = zero(y)
+    @test minmod(0,0) == minmod_orig(0,0)
+    @test minmod(0.0, y) == minmod_orig(0.0, y)
+    @test minmod(0.0, -y) == minmod_orig(0.0, -y)
+    for _ in 1:100
+        x = rand()
+        y = rand()
+        @test minmod(x, y) == minmod_orig(x, y)
+    end
+end
+
+@testset "minmod(x1, x2, x3, x4)" begin
+    y = rand()
+    x = zero(y)
+    @test minmod(0,0) == minmod_orig(0,0)
+    @test minmod(0.0, y) == minmod_orig(0.0, y)
+    @test minmod(0.0, -y) == minmod_orig(0.0, -y)
+    for _ in 1:100
+        x = rand()
+        y = rand()
+        @test minmod_orig(x, y) == minmod_orig(x, y)
+    end
+end


### PR DESCRIPTION
- `ArrayBuffer` という型を作成し `calc_rhs` などで作成した配列を使い回す設計にしました a2989bf9ea47f9e5419aa8f864b497c4b13817d8
- inline inbounds マクロで 9f950031cdc33ecdd3129d3364b3a45abc21eefc 高速化をしました．
- minmod 関数の最適化を aa35eeb26991cab07deb6b29039feb7d12731439 で行いました．
    - Julia の `sign` 関数の実行コストが重いので使いまわせる値は使いまわしています．
    - `min(x1, x2, x3, x4)` の代わりに `min(min(x1, x2), min(x3, x4))` にすると `min` の比較回数が減るので nano sec オーダーで速くなります，この僅かな高速化が main 関数内にある output のループでみると１秒ほど縮むのでこの改善も入れました．

結果として C++ の `-O2` フラグ最適化程度には速くなりました．

<img width="1706" alt="image" src="https://github.com/user-attachments/assets/0186c995-4e08-4154-954e-c6270aa62361">
